### PR TITLE
Lab 3 - Add Functional and Nightwatch Tests

### DIFF
--- a/web/modules/custom/my_testing_module/my_testing_module.routing.yml
+++ b/web/modules/custom/my_testing_module/my_testing_module.routing.yml
@@ -4,7 +4,7 @@ my_testing_module.my_message:
     _controller: '\Drupal\my_testing_module\Controller\MyMessageController::displayMessage'
     _title_callback: '\Drupal\my_testing_module\Controller\MyMessageController::title'
   requirements:
-    _permission: 'access content'
+    _role: 'authenticated'
 
 my_testing_module.settings:
   path: 'admin/config/system/my_testing_module/settings'

--- a/web/modules/custom/my_testing_module/tests/src/Functional/MyFunctionalTest.php
+++ b/web/modules/custom/my_testing_module/tests/src/Functional/MyFunctionalTest.php
@@ -51,6 +51,17 @@ class MyFunctionalTest extends BrowserTestBase {
     $this->drupalLogin($this->authorizedUser);
     $this->drupalGet('my-message');
     $assert->pageTextContains('Hi Regular User.');
+    $assert->statusCodeEquals(200);
+  }
+
+  /**
+   * Confirm unauthenticated users can't access controller route.
+   */
+  public function testMessageControllerDoesntLoadForUnauthenticatedUsers() {
+    $assert = $this->assertSession();
+    $this->drupalGet('my-message');
+    $assert->pageTextContains('You are not authorized to access this page.');
+    $assert->statusCodeEquals(403);
   }
 
 }

--- a/web/modules/custom/my_testing_module/tests/src/Functional/MyFunctionalTest.php
+++ b/web/modules/custom/my_testing_module/tests/src/Functional/MyFunctionalTest.php
@@ -46,22 +46,19 @@ class MyFunctionalTest extends BrowserTestBase {
   /**
    * Functional test confirming the controller is loading.
    */
-  public function testMessageControllerIsLoadingForAuthenticatedUsers() {
+  public function testMessageControllerProperlyHandlesAccessControls() {
     $assert = $this->assertSession();
+
+    // Test unauthenticated users can't access the controller.
+    $this->drupalGet('my-message');
+    $assert->pageTextContains('You are not authorized to access this page.');
+    $assert->statusCodeEquals(403);
+
+    // Test authenticated users can access the controller.
     $this->drupalLogin($this->authorizedUser);
     $this->drupalGet('my-message');
     $assert->pageTextContains('Hi Regular User.');
     $assert->statusCodeEquals(200);
-  }
-
-  /**
-   * Confirm unauthenticated users can't access controller route.
-   */
-  public function testMessageControllerDoesntLoadForUnauthenticatedUsers() {
-    $assert = $this->assertSession();
-    $this->drupalGet('my-message');
-    $assert->pageTextContains('You are not authorized to access this page.');
-    $assert->statusCodeEquals(403);
   }
 
 }

--- a/web/modules/custom/my_testing_module/tests/src/Nightwatch/MyNightwatchTest.js
+++ b/web/modules/custom/my_testing_module/tests/src/Nightwatch/MyNightwatchTest.js
@@ -2,17 +2,68 @@ module.exports = {
   '@tags': ['my_testing_module'],
   before: function(browser) {
     browser
-      .drupalInstall();
+      .drupalInstall({
+        setupFile: __dirname + '/fixtures/TestSiteInstallTestScript.php',
+      });
   },
   after: function(browser) {
     browser
       .drupalUninstall();
   },
-  'Visit the home page and ensure "Skip to main content" is present': (browser) => {
+  'Visit the message module settings and toggle log settings': (browser) => {
+    // Navigate to module admin setting.
     browser
-      .drupalRelativeURL('/')
-      .assert.containsText('body', 'Skip to main content')
+      .drupalLoginAsAdmin()
+      .drupalRelativeURL('/admin/config/system/my_testing_module/settings');
+
+    // Confirm label contains correct CSS class.
+    browser
+      .assert.cssClassPresent('label[for=edit-log-users]', 'my-unchecked-class')
+      .assert.not.cssClassPresent('label[for=edit-log-users]', 'my-checked-class')
+      .execute(function() {
+          return Drupal.myMessageLogging.myCheckbox.checked;
+        }, [], function (result) {
+          browser.assert.strictEqual(result.value, false);
+        });
+
+    // Toggle the checkbox state.
+    browser
+      .click('input[name=log_users]');
+
+    // Confirm label contains correct CSS class.
+    browser
+      .assert.not.cssClassPresent('label[for=edit-log-users]', 'my-unchecked-class')
+      .assert.cssClassPresent('label[for=edit-log-users]', 'my-checked-class')
+      .execute(function() {
+          return Drupal.myMessageLogging.myCheckbox.checked;
+        }, [], function (result) {
+          browser.assert.strictEqual(result.value, true);
+        });
+
+    // Toggle the checkbox state again.
+    browser
+      .click('input[name=log_users]');
+
+    // Confirm label contains correct CSS class.
+    browser
+      .assert.cssClassPresent('label[for=edit-log-users]', 'my-unchecked-class')
+      .assert.not.cssClassPresent('label[for=edit-log-users]', 'my-checked-class')
+      .execute(function() {
+          return Drupal.myMessageLogging.myCheckbox.checked;
+        }, [], function (result) {
+          browser.assert.strictEqual(result.value, false);
+        });
+
+    // Clean up our session.
+    browser
       .end();
-  },
+  }
+  // 'Visit the home page and ensure "Skip to main content" is present': (browser) => {
+  //   browser
+  //     .drupalRelativeURL('/')
+  //     .assert.containsText('body', 'Skip to main content')
+  //     .end();
+  // },
+
 
 };

--- a/web/modules/custom/my_testing_module/tests/src/Nightwatch/fixtures/TestSiteInstallTestScript.php
+++ b/web/modules/custom/my_testing_module/tests/src/Nightwatch/fixtures/TestSiteInstallTestScript.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\TestSite;
+
+/**
+ * Setup file used by Nightwatch tests.
+ */
+class TestSiteInstallTestScript implements TestSetupInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setup() {
+    $modules = ['my_testing_module'];
+    \Drupal::service('module_installer')->install($modules);
+  }
+
+}


### PR DESCRIPTION
[Lab 3](/WidgetsBurritos/drupal-test-writing/wiki/Lab-%233:-Writing-system-tests-with-BrowserTestBase-and-Nightwatch.js) continues to build on the functionality we did in #3 (notice this PR is against `lab-2-kernel-test`, not `9.x`). 

- In the first commit, we resolve a security issue related to permissions for /my-message.
- In the second commit, we introduce a very simple nightwatch.js test to test toggling of a checkbox. 
- In the third commit, we do a minor refactor on the functional test, to consolidate multiple test cases into a single test case. 