### PR TITLE
Lab 4 - Add Behat Acceptance Test

### DIFF
--- a/features/drupal/my-message.feature
+++ b/features/drupal/my-message.feature
@@ -3,7 +3,7 @@ Feature: My Message
   Verify that the "My Message" route correctly handles user roles.
 
   Scenario: Verified unauthenticated users
-    Given I am on "/my-message"
+    When I am on "/my-message"
     Then the response status code should be 403
     And the response should contain "You are not authorized to access this page."
     And the response should not contain "You are logged in"
@@ -13,7 +13,7 @@ Feature: My Message
   @api
   Scenario: Verify users with "my super secret privilege"
     Given I am logged in as a user with the "my super secret privilege" permission
-    And I am on "/my-message"
+    When I am on "/my-message"
     Then the response status code should be 200
     And the response should contain "You are logged in"
     And the response should contain "You are special"
@@ -22,7 +22,7 @@ Feature: My Message
   @api
   Scenario: Verify users with "yet another privilege"
     Given I am logged in as a user with the "yet another privilege" permission
-    And I am on "/my-message"
+    When I am on "/my-message"
     Then the response status code should be 200
     And the response should contain "You are logged in"
     And the response should not contain "You are special"
@@ -34,15 +34,15 @@ Feature: My Message
   @api
   Scenario Outline:
     Given I am logged in as a user with the "<permission>" permission
-    And I am on "/my-message"
+    When I am on "/my-message"
     Then the response status code should be 200
     And the response should <logged in> "You are logged in"
     And the response should <special> "You are special"
     And the response should <yet another> "You have yet another privilege"
 
     Scenarios:
-    | permission                | logged in | special | yet another |
-    | access content        | contain   | not contain | not contain |
-    | my super secret privilege | contain   | contain | not contain |
-    | yet another privilege     | contain   | not contain | contain |
-    | my super secret privilege, yet another privilege     | contain   | contain | contain |
+    | permission                                           | logged in | special     | yet another |
+    | access content                                       | contain   | not contain | not contain |
+    | my super secret privilege                            | contain   | contain     | not contain |
+    | yet another privilege                                | contain   | not contain | contain     |
+    | my super secret privilege, yet another privilege     | contain   | contain     | contain     |

--- a/features/drupal/my-message.feature
+++ b/features/drupal/my-message.feature
@@ -1,0 +1,48 @@
+Feature: My Message
+
+  Verify that the "My Message" route correctly handles user roles.
+
+  Scenario: Verified unauthenticated users
+    Given I am on "/my-message"
+    Then the response status code should be 403
+    And the response should contain "You are not authorized to access this page."
+    And the response should not contain "You are logged in"
+    And the response should not contain "You are special"
+    And the response should not contain "You have yet another privilege"
+
+  @api
+  Scenario: Verify users with "my super secret privilege"
+    Given I am logged in as a user with the "my super secret privilege" permission
+    And I am on "/my-message"
+    Then the response status code should be 200
+    And the response should contain "You are logged in"
+    And the response should contain "You are special"
+    And the response should not contain "You have yet another privilege"
+
+  @api
+  Scenario: Verify users with "yet another privilege"
+    Given I am logged in as a user with the "yet another privilege" permission
+    And I am on "/my-message"
+    Then the response status code should be 200
+    And the response should contain "You are logged in"
+    And the response should not contain "You are special"
+    And the response should contain "You have yet another privilege"
+
+
+# CONSOLIDATED RULE FOR ALL 200 status permissions:
+
+  @api
+  Scenario Outline:
+    Given I am logged in as a user with the "<permission>" permission
+    And I am on "/my-message"
+    Then the response status code should be 200
+    And the response should <logged in> "You are logged in"
+    And the response should <special> "You are special"
+    And the response should <yet another> "You have yet another privilege"
+
+    Scenarios:
+    | permission                | logged in | special | yet another |
+    | access content        | contain   | not contain | not contain |
+    | my super secret privilege | contain   | contain | not contain |
+    | yet another privilege     | contain   | not contain | contain |
+    | my super secret privilege, yet another privilege     | contain   | contain | contain |


### PR DESCRIPTION
[Lab 4](/WidgetsBurritos/drupal-test-writing/wiki/Lab-%234:-Writing-acceptance-tests-with-behat) continues to build on the functionality we did in #4 (notice this PR is against `lab-3-functional-test`, not `9.x`). 

This PR adds a simple acceptance test outlining the doubles down on the security posture.